### PR TITLE
PHP 8.5 compatibility

### DIFF
--- a/app/src/Encryption/functions.php
+++ b/app/src/Encryption/functions.php
@@ -109,12 +109,11 @@ function decodeDecrypt(string $base64NonceCipherText): string
 
 function decryptValues(array $encryptedKeys, array $keyValues): array
 {
-    return mb_convert_encoding(
-        cipherValues($encryptedKeys, $keyValues, function (string $text) {
-            return decodeDecrypt($text);
-        }),
-        'UTF-8'
-    ) ?: [];
+    $result = cipherValues($encryptedKeys, $keyValues, function (string $text) {
+        return decodeDecrypt($text);
+    });
+
+    return $result ?: [];
 }
 
 function encryptValues(array $encryptedKeys, array $keyValues): array

--- a/app/src/Legacy/Classes/DB.php
+++ b/app/src/Legacy/Classes/DB.php
@@ -118,7 +118,7 @@ class DB
         ];
         $this->pdo_options = $this->pdo_default_attrs + $this->pdoAttrs;
         $this->pdo_options[PDO::ATTR_ERRMODE] = PDO::ERRMODE_EXCEPTION;
-        $this->pdo_options[PDO::MYSQL_ATTR_INIT_COMMAND] = "SET time_zone = '+00:00', NAMES 'utf8mb4'";
+        $this->pdo_options[class_exists('Pdo\\Mysql') ? \Pdo\Mysql::ATTR_INIT_COMMAND : PDO::MYSQL_ATTR_INIT_COMMAND] = "SET time_zone = '+00:00', NAMES 'utf8mb4'";
         self::$dbh = new PDO($pdo_connect, $this->user, $this->pass, $this->pdo_options);
         self::$dbh->setAttribute(PDO::ATTR_EMULATE_PREPARES, true);
         self::$instance = $this;

--- a/app/src/Legacy/Classes/Variable.php
+++ b/app/src/Legacy/Classes/Variable.php
@@ -95,7 +95,9 @@ class Variable
         foreach ($rows as &$row) {
             $row = DB::formatRow($row);
             if (hasEncryption() && in_array($row['name'], static::ENCRYPTED_NAMES)) {
-                $row['value'] = decodeDecrypt($row['value']);
+                $row['value'] = is_string($row['value']) && $row['value'] !== ''
+                    ? decodeDecrypt($row['value'])
+                    : $row['value'];
             }
             static::populate(
                 name: $row['name'],
@@ -283,7 +285,9 @@ class Variable
         }
         $return = DB::formatRow($return);
         if (hasEncryption() && in_array($name, static::ENCRYPTED_NAMES)) {
-            $return['value'] = decodeDecrypt($return['value']);
+            $return['value'] = is_string($return['value']) && $return['value'] !== ''
+                ? decodeDecrypt($return['value'])
+                : $return['value'];
         }
         static::populate(
             name: $name,

--- a/app/src/Legacy/G/functions.php
+++ b/app/src/Legacy/G/functions.php
@@ -693,7 +693,9 @@ function is_valid_timezone(string $tzid): bool
     $tza = timezone_abbreviations_list();
     foreach ($tza as $zone) {
         foreach ($zone as $item) {
-            $valid[$item['timezone_id']] = true;
+            if ($item['timezone_id'] !== null) {
+                $valid[$item['timezone_id']] = true;
+            }
         }
     }
     unset($valid['']);


### PR DESCRIPTION
Closes #114 

It appears that adding compatibility for 8.5 wasn't as hard as expected

With these changes I have suppressed errors in 8.5

You are welcome to push any other changes in case it feels adequate

The variable part was because of an issue during the update. I'm not 100% sure if it could be related to 8.5 itself, because I was getting an error on update. Probably unrelated, so feel free to remove that part.

I can only acknowledge the `app/src/Legacy/Classes/DB.php` part that is the one that. The rest of the code has been done with Sonnet 4.6 assistance. If its useless close this PR.

<img width="1059" height="489" alt="image" src="https://github.com/user-attachments/assets/7373f30a-3567-4835-9368-9d71048179b4" />



